### PR TITLE
Database Module Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Mongoose would be easy for you to add to this scaffold.
 If you would like to read up more on how to setup and seed a MongoDB with this
 project [checkout the README](mock_data/mongo_seeds/README.md) in the `mock_data/mongo_seeds` directory.
 
+You can also read up on the `DatabaseModule` and how to configure it for
+a [different provider here](backend/src/database/README.md).
+
 ## FAQ
 
 **Some of this code seems a bit messy?**

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ is often easier for newer and developers to understand and quick onboarding time
 **This is using Mongo but I prefer SQL.**
 
 Hey I like SQL too, and my hope is to add a SQL solution to this project in the future so that those who use it can
-quickly configure their `DatabaseModule` to use the solution they prefer.
+quickly configure their `DatabaseModule` to use the solution they prefer. You can read up on the `DatabaseModule` and
+how to configure it for
+a [different provider here](backend/src/database/README.md).
 
 **Why the Commitment to certain providers?**
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard, PermissionGuard } from './utility/guards';
+import { DatabaseModule } from './database';
 import { UserModule } from './routes/user';
 import { AuthModule } from './routes/auth';
 import { AclsModule } from './routes/acls';
-import { MailModule } from './mail';
 
 @Module({
-  imports: [AuthModule, UserModule, AclsModule, MailModule],
+  imports: [DatabaseModule, AuthModule, UserModule, AclsModule],
   controllers: [],
   providers: [
     { provide: APP_GUARD, useClass: JwtAuthGuard },

--- a/backend/src/database/README.md
+++ b/backend/src/database/README.md
@@ -1,0 +1,16 @@
+# Database Module
+
+The database Module is setup to essentially extend off the databsse provider you decide to use. Currently the project
+only has a subdirectory for MongoDB but could be extended to use others in the future.
+
+Other modules in the backend all import the `DatabaseModule` and utilize the `DatabaseService` so switching database
+providers can be achieved by changing what underlying service the `DatabaseService` is extending.
+
+The `intializeDatabase` function folows a similar principal, taking in an argument for the database connection you want
+to establish and then running the relevant initialization function from the relevant subdirectory.
+
+### Some controllers may still need to be updated directly in their services
+
+Currently some of the back-end services do have Mongo specific functionality coded into them that may need to be
+updated. This like finding a user account by email in the `UsersService` are written with the query aligning with the
+MongoDB node driver. My hpe is to update this in the future.

--- a/backend/src/database/database.intialize.ts
+++ b/backend/src/database/database.intialize.ts
@@ -1,0 +1,14 @@
+import { initMongoDatabase } from './mongo';
+import { Logger } from '@nestjs/common';
+
+export async function initializeDatabase(databaseProvider: 'MONGO'): Promise<any> {
+  if (databaseProvider === 'MONGO') {
+    try {
+      return await initMongoDatabase();
+    } catch (e) {
+      Logger.error(e);
+    }
+  } else {
+    throw new Error('Not a valid database provider');
+  }
+}

--- a/backend/src/database/database.module.ts
+++ b/backend/src/database/database.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+@Module({
+  providers: [DatabaseService],
+  exports: [DatabaseService],
+})
+export class DatabaseModule {}

--- a/backend/src/database/database.service.ts
+++ b/backend/src/database/database.service.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { MongoService } from './mongo';
+
+@Injectable()
+export class DatabaseService extends MongoService {}

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -1,0 +1,3 @@
+export * from './database.module';
+export * from './database.service';
+export * from './database.intialize';

--- a/backend/src/database/mongo/index.ts
+++ b/backend/src/database/mongo/index.ts
@@ -1,4 +1,3 @@
-export * from './mongo.module';
 export * from './mongo.service';
 export * from './mongo.initialize';
 export * from './mongo.testhelp';

--- a/backend/src/database/mongo/mongo.initialize.ts
+++ b/backend/src/database/mongo/mongo.initialize.ts
@@ -5,19 +5,19 @@ const mongoClient = new MongoClient(environment.database.mongo_uri, {});
 
 let _db;
 
-const initMongoDatabase = (callback) => {
+const initMongoDatabase = () => {
   if (_db) {
-    console.log('Connection already exists');
-    return callback(null, _db);
+    //connection already exists
+    throw new Error('Database Connection Already Exists');
   }
-  mongoClient
+  return mongoClient
     .connect()
     .then((client) => {
       _db = client.db(environment.database.name);
-      callback(null, _db);
+      return _db;
     })
     .catch((error) => {
-      callback(error);
+      throw new Error(error);
     });
 };
 

--- a/backend/src/database/mongo/mongo.module.ts
+++ b/backend/src/database/mongo/mongo.module.ts
@@ -1,8 +1,0 @@
-import { Module } from '@nestjs/common';
-import { MongoService } from './mongo.service';
-
-@Module({
-  providers: [MongoService],
-  exports: [MongoService],
-})
-export class MongoModule {}

--- a/backend/src/database/mongo/mongo.service.ts
+++ b/backend/src/database/mongo/mongo.service.ts
@@ -1,12 +1,12 @@
-import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
-import { ObjectId } from 'mongodb';
+import {Injectable, InternalServerErrorException, Logger, NotFoundException} from '@nestjs/common';
+import {ObjectId} from 'mongodb';
 import {
   BaseCreationInterface,
   BaseInterface,
   GenericInterface,
   SuccessMessageInterface,
 } from '../../../../shared/interfaces';
-import { DatabaseTables } from '../../../../shared/enums';
+import {DatabaseTables} from '../../../../shared/enums';
 
 @Injectable()
 export class MongoService {
@@ -25,7 +25,7 @@ export class MongoService {
     }
   }
 
-  bsonConvert(id: string | ObjectId): ObjectId {
+  idConvert(id: string | ObjectId): ObjectId {
     if (typeof id === 'string') {
       return new ObjectId(id);
     }
@@ -38,7 +38,7 @@ export class MongoService {
 
   async getSingleItem(collection: DatabaseTables, _id: string): Promise<BaseInterface> {
     try {
-      const result = await this._db.collection(collection).findOne({ _id: this.bsonConvert(_id) });
+      const result = await this._db.collection(collection).findOne({_id: this.idConvert(_id)});
       if (result) {
         return result;
       } else {
@@ -53,9 +53,9 @@ export class MongoService {
   async getAllOrgItems(collection: DatabaseTables, id_organization: string): Promise<BaseInterface[]> {
     try {
       const result = await this._db
-        .collection(collection)
-        .find({ id_organization: this.bsonConvert(id_organization) })
-        .toArray();
+          .collection(collection)
+          .find({id_organization: this.idConvert(id_organization)})
+          .toArray();
       if (result) {
         return result;
       } else {
@@ -70,9 +70,9 @@ export class MongoService {
   async getAllUserItems(collection: DatabaseTables, id_user: string | ObjectId): Promise<BaseInterface[]> {
     try {
       const result = await this._db
-        .collection(collection)
-        .find({ id_user: this.bsonConvert(id_user) })
-        .toArray();
+          .collection(collection)
+          .find({id_user: this.idConvert(id_user)})
+          .toArray();
       if (result) {
         return result;
       } else {
@@ -88,7 +88,7 @@ export class MongoService {
     try {
       const result = await this._db.collection(collection).insertOne(item);
       if (result) {
-        return { _id: result.insertedId, ...item };
+        return {_id: result.insertedId, ...item};
       }
     } catch (err) {
       Logger.error(`DB Service: Failed to insert type: [${item.type}]`);
@@ -98,8 +98,8 @@ export class MongoService {
 
   async deleteSingleItem(collection: DatabaseTables, _id: string): Promise<SuccessMessageInterface> {
     try {
-      await this._db.collection(collection).deleteOne({ _id: this.bsonConvert(_id) });
-      return { message: 'success' };
+      await this._db.collection(collection).deleteOne({_id: this.idConvert(_id)});
+      return {message: 'success'};
     } catch (err) {
       Logger.error(`DB Service: Failed to delete item from collection: [${collection}] with id: [${_id}]`);
       throw new InternalServerErrorException(`Unable to delete item`);
@@ -107,15 +107,15 @@ export class MongoService {
   }
 
   async updateSingleItem(
-    collection: DatabaseTables,
-    id: string,
-    item: GenericInterface | BaseInterface,
+      collection: DatabaseTables,
+      id: string,
+      item: GenericInterface | BaseInterface,
   ): Promise<BaseInterface> {
     try {
-      const options = { upsert: false, returnDocument: 'after' };
+      const options = {upsert: false, returnDocument: 'after'};
       const result = await this._db
-        .collection(collection)
-        .findOneAndUpdate({ _id: this.bsonConvert(id) }, { $set: item }, options);
+          .collection(collection)
+          .findOneAndUpdate({_id: this.idConvert(id)}, {$set: item}, options);
       if (result.value._id) {
         return result.value;
       } else {

--- a/backend/src/database/mongo/mongo.testhelp.ts
+++ b/backend/src/database/mongo/mongo.testhelp.ts
@@ -5,7 +5,7 @@ let databaseConnection: MongoClient = null;
 
 export async function TestConnectLocalDb(): Promise<Db> {
   try {
-    //console.log("\x1b[36m%s\x1b[0m", "opening connection to local db");
+    console.log('\x1b[36m%s\x1b[0m', 'opening connection to local db');
     const db_uri = environment.database.mongo_uri;
     const mongoClient = new MongoClient(db_uri, {});
     databaseConnection = await mongoClient.connect();
@@ -17,7 +17,7 @@ export async function TestConnectLocalDb(): Promise<Db> {
 
 export async function TestCloseLocalDb(): Promise<void> {
   try {
-    //console.log("\x1b[36m%s\x1b[0m", "closing connection to local db");
+    console.log('\x1b[36m%s\x1b[0m', 'closing connection to local db');
     await databaseConnection.close();
   } catch (e) {
     console.log('FAILURE TO CLOSE DB CONNECTION');

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,32 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { INestApplication, Logger, ValidationPipe } from '@nestjs/common';
-import { initMongoDatabase, MongoService } from './database/mongo';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { environment } from '../environments/environment';
+import { DatabaseService, initializeDatabase } from './database';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     rawBody: true,
   });
-  setupDatabase(app);
+  app.get(DatabaseService).assignDatabase(await initializeDatabase('MONGO'));
   app.setGlobalPrefix('api');
   app.enableCors();
-  app.useGlobalPipes(
-    new ValidationPipe({ whitelist: true, disableErrorMessages: false }),
-  );
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, disableErrorMessages: false }));
   await app.listen(process.env.port || 3000, () => {
     Logger.log(`BUILD :::: ${environment.name}`);
-  });
-}
-
-function setupDatabase(app: INestApplication) {
-  initMongoDatabase((err, db) => {
-    if (err) {
-      Logger.warn('Failed to Connect to Mongo Database, is it running?');
-      Logger.error(err);
-    } else {
-      app.get(MongoService).assignDatabase(db);
-    }
+    app.get(DatabaseService).database ? Logger.log(`DATABASE EXISTS`) : Logger.error(`MISSING DATABASE`);
   });
 }
 

--- a/backend/src/routes/acls/acls.module.ts
+++ b/backend/src/routes/acls/acls.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AclsService } from './acls.service';
 import { AclsController } from './acls.controller';
-import { MongoModule } from '../../database/mongo';
+import { DatabaseModule } from '../../database';
 import { MailModule } from '../../mail';
 
 @Module({
-  imports: [MongoModule, MailModule],
+  imports: [DatabaseModule, MailModule],
   controllers: [AclsController],
   providers: [AclsService],
   exports: [AclsService],

--- a/backend/src/routes/acls/acls.service.ts
+++ b/backend/src/routes/acls/acls.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
 import { AclDto } from './acl.dto';
-import { MongoService } from '../../database/mongo';
+import { DatabaseService } from '../../database';
 import { DatabaseTables, TypesEnum } from '../../../../shared/enums';
 import {
   AclInterface,
@@ -14,7 +14,7 @@ import { MailService } from '../../mail';
 
 @Injectable()
 export class AclsService {
-  constructor(private dbService: MongoService, private mailService: MailService) {}
+  constructor(private dbService: DatabaseService, private mailService: MailService) {}
 
   private aclCollection = DatabaseTables.ACLS;
 

--- a/backend/src/routes/acls/acls.service.ts
+++ b/backend/src/routes/acls/acls.service.ts
@@ -25,7 +25,7 @@ export class AclsService {
   async create(id_organization: string, createAclDto: AclDto): Promise<AclInterface> {
     const newAcl: BaseAclInterface = {
       id_user: null,
-      id_organization: this.dbService.bsonConvert(id_organization),
+      id_organization: this.dbService.idConvert(id_organization),
       permission: createAclDto.permission,
       type: TypesEnum.ACL,
       name_organization: createAclDto.name_organization,
@@ -71,9 +71,9 @@ export class AclsService {
   async assignUserToAcl(id_acl: string, user: UserInterface): Promise<AclInterface> {
     try {
       const options = { upsert: false, returnDocument: 'after' };
-      const update = { id_user: this.dbService.bsonConvert(user._id), name_user: user.name };
+      const update = { id_user: this.dbService.idConvert(user._id), name_user: user.name };
       const result = await this.db.findOneAndUpdate(
-        { _id: this.dbService.bsonConvert(id_acl) },
+        { _id: this.dbService.idConvert(id_acl) },
         { $set: update },
         options,
       );

--- a/backend/src/routes/acls/acls.service.ts
+++ b/backend/src/routes/acls/acls.service.ts
@@ -68,7 +68,7 @@ export class AclsService {
     throw new NotFoundException('Invite Not Found.');
   }
 
-  async assignUserToAcl(id_acl: string, user: UserInterface) {
+  async assignUserToAcl(id_acl: string, user: UserInterface): Promise<AclInterface> {
     try {
       const options = { upsert: false, returnDocument: 'after' };
       const update = { id_user: this.dbService.bsonConvert(user._id), name_user: user.name };
@@ -80,11 +80,11 @@ export class AclsService {
       if (result.value._id) {
         return result.value;
       } else {
-        new InternalServerErrorException(`Unable to update item. No result returned.`);
+        throw new InternalServerErrorException(`Unable to update item. No result returned.`);
       }
     } catch (err) {
       Logger.error(`DB Service: Unable to assign acl with id: [${id_acl}] to user with id [${user._id}]`);
-      throw new InternalServerErrorException(`Update of item was not successful`);
+      throw new InternalServerErrorException(`Update of item was not successful. No result returned.`);
     }
   }
 }

--- a/backend/src/routes/auth/auth.module.ts
+++ b/backend/src/routes/auth/auth.module.ts
@@ -6,12 +6,12 @@ import { JwtModule } from '@nestjs/jwt';
 import { environment } from '../../../environments/environment';
 import { JwtStrategy } from './jwt.strategy';
 import { UserModule } from '../user';
-import { MongoModule } from '../../database/mongo';
+import { DatabaseModule } from '../../database';
 import { AclsModule } from '../acls';
 
 @Module({
   imports: [
-    MongoModule,
+    DatabaseModule,
     UserModule,
     AclsModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),

--- a/backend/src/routes/auth/auth.service.ts
+++ b/backend/src/routes/auth/auth.service.ts
@@ -10,13 +10,13 @@ import { EmailOnlyDto, LoginDto, SignupDto } from './auth.dto';
 import { JwtService } from '@nestjs/jwt';
 import { PermissionEnum } from '../../../../shared/enums';
 import { UserService } from '../user';
-import { MongoService } from '../../database/mongo';
+import { DatabaseService } from '../../database';
 import { AclsService } from '../acls';
 
 @Injectable()
 export class AuthService {
   constructor(
-    private dbService: MongoService,
+    private dbService: DatabaseService,
     private userService: UserService,
     private aclService: AclsService,
     private JWT_SERVICE: JwtService,
@@ -130,21 +130,21 @@ export class AuthService {
   }
 
   /*async checkValidityOfResetLink(id: string): Promise<boolean> {
-                  return !!(await this._invite.getPasswordResetToken(id));
-                }
-          
-                 async resetUserPassword(reset_id: string, resetReq: PasswordResetDto): Promise<boolean> {
-                     const resetInfo = await this._invite.getPasswordResetToken(reset_id);
-                  if (resetReq.email == resetInfo?.email) {
-                    const newPassword = await this.passwordEncrypt({
-                      password: resetReq.password,
-                      passwordConfirm: resetReq.passwordConfirm,
-                    });
-                    const result = await this.userService.updatePassword(resetInfo.user, newPassword);
-                    this._invite.deletePasswordReset(reset_id);
-                    return result;
+                    return !!(await this._invite.getPasswordResetToken(id));
                   }
-          
-                  throw new UnprocessableEntityException('Not a valid Password Reset Request');
-                }*/
+            
+                   async resetUserPassword(reset_id: string, resetReq: PasswordResetDto): Promise<boolean> {
+                       const resetInfo = await this._invite.getPasswordResetToken(reset_id);
+                    if (resetReq.email == resetInfo?.email) {
+                      const newPassword = await this.passwordEncrypt({
+                        password: resetReq.password,
+                        passwordConfirm: resetReq.passwordConfirm,
+                      });
+                      const result = await this.userService.updatePassword(resetInfo.user, newPassword);
+                      this._invite.deletePasswordReset(reset_id);
+                      return result;
+                    }
+            
+                    throw new UnprocessableEntityException('Not a valid Password Reset Request');
+                  }*/
 }

--- a/backend/src/routes/user/user.module.ts
+++ b/backend/src/routes/user/user.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
-import { MongoModule } from '../../database/mongo';
+import { DatabaseModule } from '../../database';
 import { MailModule } from '../../mail';
 
 @Module({
-  imports: [MongoModule, MailModule],
+  imports: [DatabaseModule, MailModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/backend/src/routes/user/user.service.spec.ts
+++ b/backend/src/routes/user/user.service.spec.ts
@@ -1,30 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
-import {
-  MongoService,
-  TestCloseLocalDb,
-  TestConnectLocalDb,
-} from '../../database/mongo';
-import {
-  MOCK_ADMIN_TOKEN,
-  MOCK_RESIDENT_TOKEN,
-} from '../../../test/token_helper';
+import { TestCloseLocalDb, TestConnectLocalDb } from '../../database/mongo';
+import { MOCK_ADMIN_TOKEN, MOCK_RESIDENT_TOKEN } from '../../../test/token_helper';
 import { UserInterface } from '../../../../shared/interfaces';
 import { TypesEnum } from '../../../../shared/enums';
 import { ForbiddenException } from '@nestjs/common';
 import { UserEditDto } from './user.dto';
+import { DatabaseService } from '../../database';
 
 const SEED_DATA: UserInterface[] = require('../../../mongo_seeds/seed_data/users.json');
 
 describe('UserService', () => {
   let service: UserService;
-  let db: MongoService;
+  let db: DatabaseService;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService, MongoService],
+      providers: [UserService, DatabaseService],
     }).compile();
-    db = module.get<MongoService>(MongoService);
+    db = module.get<DatabaseService>(DatabaseService);
     db.assignDatabase(await TestConnectLocalDb());
     service = module.get<UserService>(UserService);
   });
@@ -87,16 +81,12 @@ describe('UserService', () => {
 
   it("should prevent user from updating someone else's user", async () => {
     const phoneUpdate = { ...getUserDto(SEED_DATA[0]), phone: '8825550119' };
-    await expect(
-      service.updateUser(MOCK_RESIDENT_TOKEN, phoneUpdate),
-    ).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(service.updateUser(MOCK_RESIDENT_TOKEN, phoneUpdate)).rejects.toBeInstanceOf(ForbiddenException);
   });
 
   it("should prevent admin from updating someone else's user", async () => {
     const phoneUpdate = { ...getUserDto(SEED_DATA[1]), phone: '8825550119' };
-    await expect(
-      service.updateUser(MOCK_ADMIN_TOKEN, phoneUpdate),
-    ).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(service.updateUser(MOCK_ADMIN_TOKEN, phoneUpdate)).rejects.toBeInstanceOf(ForbiddenException);
   });
 });
 

--- a/backend/src/routes/user/user.service.ts
+++ b/backend/src/routes/user/user.service.ts
@@ -5,15 +5,16 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { BaseUserInterface, TokenInterface, UserInterface } from '../../../../shared/interfaces';
-import { SignupDto, UserEditDto } from './user.dto';
-import { DatabaseTables, TypesEnum } from '../../../../shared/enums';
-import { MongoService } from '../../database/mongo';
-import { MailService } from '../../mail';
+import {BaseUserInterface, TokenInterface, UserInterface} from '../../../../shared/interfaces';
+import {SignupDto, UserEditDto} from './user.dto';
+import {DatabaseTables, TypesEnum} from '../../../../shared/enums';
+import {MongoService} from '../../database/mongo';
+import {MailService} from '../../mail';
 
 @Injectable()
 export class UserService {
-  constructor(private dbService: MongoService, private mailService: MailService) {}
+  constructor(private dbService: MongoService, private mailService: MailService) {
+  }
 
   private usersCollection = DatabaseTables.USERS;
 
@@ -24,7 +25,7 @@ export class UserService {
   async getUser(token: TokenInterface): Promise<UserInterface> {
     try {
       const account = (await this.db.findOne({
-        _id: this.dbService.bsonConvert(token.uid),
+        _id: this.dbService.idConvert(token.uid),
       })) as UserInterface;
       return this.cleanUser(account);
     } catch (err) {
@@ -34,7 +35,7 @@ export class UserService {
 
   async getUserByEmail(email: string, withPassword = false): Promise<UserInterface> {
     try {
-      const account = (await this.db.findOne({ email: email })) as UserInterface;
+      const account = (await this.db.findOne({email: email})) as UserInterface;
       if (withPassword) {
         //return object includes password, careful!
         return account;
@@ -50,11 +51,11 @@ export class UserService {
     const id = updates._id;
     if (id == token.uid) {
       delete updates['_id'];
-      const updatedUserAttempt = { type: TypesEnum.USER, ...updates };
+      const updatedUserAttempt = {type: TypesEnum.USER, ...updates};
       const result = (await this.dbService.updateSingleItem(
-        this.usersCollection,
-        id,
-        updatedUserAttempt,
+          this.usersCollection,
+          id,
+          updatedUserAttempt,
       )) as UserInterface;
 
       return this.cleanUser(result);
@@ -87,7 +88,7 @@ export class UserService {
 
   async ensureUniqueEmail(emailCheck: string): Promise<boolean> {
     try {
-      const result = await this.db.findOne({ email: emailCheck });
+      const result = await this.db.findOne({email: emailCheck});
       return !result;
     } catch (err) {
       Logger.error(`Failed to lookup user by email on unique check: [${emailCheck}]`);
@@ -97,12 +98,12 @@ export class UserService {
 
   async updatePassword(account_id: string, newPassword: string): Promise<boolean> {
     try {
-      const update = { password: newPassword };
-      const options = { upsert: false, returnDocument: 'after' };
+      const update = {password: newPassword};
+      const options = {upsert: false, returnDocument: 'after'};
       const result = await this.db.findOneAndUpdate(
-        { _id: this.dbService.bsonConvert(account_id) },
-        { $set: update },
-        options,
+          {_id: this.dbService.idConvert(account_id)},
+          {$set: update},
+          options,
       );
       return !!result;
     } catch (e) {
@@ -111,7 +112,7 @@ export class UserService {
   }
 
   cleanUser(account: UserInterface): UserInterface {
-    const { password, ...clean } = account;
+    const {password, ...clean} = account;
     return clean;
   }
 }

--- a/backend/src/routes/user/user.service.ts
+++ b/backend/src/routes/user/user.service.ts
@@ -13,18 +13,18 @@ import { MailService } from '../../mail';
 
 @Injectable()
 export class UserService {
-  constructor(private _dbService: MongoService, private _mail: MailService) {}
+  constructor(private dbService: MongoService, private mailService: MailService) {}
 
-  private collectionString = DatabaseTables.USERS;
+  private usersCollection = DatabaseTables.USERS;
 
   get db() {
-    return this._dbService.database.collection(this.collectionString);
+    return this.dbService.database.collection(this.usersCollection);
   }
 
   async getUser(token: TokenInterface): Promise<UserInterface> {
     try {
       const account = (await this.db.findOne({
-        _id: this._dbService.bsonConvert(token.uid),
+        _id: this.dbService.bsonConvert(token.uid),
       })) as UserInterface;
       return this.cleanUser(account);
     } catch (err) {
@@ -51,8 +51,8 @@ export class UserService {
     if (id == token.uid) {
       delete updates['_id'];
       const updatedUserAttempt = { type: TypesEnum.USER, ...updates };
-      const result = (await this._dbService.updateSingleItem(
-        this.collectionString,
+      const result = (await this.dbService.updateSingleItem(
+        this.usersCollection,
         id,
         updatedUserAttempt,
       )) as UserInterface;
@@ -78,7 +78,7 @@ export class UserService {
         _id: insertResult['insertedId'],
         ...newUser,
       };
-      this._mail.sendCreationWelcomeEmail(newUser.email);
+      this.mailService.sendCreationWelcomeEmail(newUser.email);
       return this.cleanUser(returnedUser);
     } catch (err) {
       throw new InternalServerErrorException('Unable to insert new user.');
@@ -100,7 +100,7 @@ export class UserService {
       const update = { password: newPassword };
       const options = { upsert: false, returnDocument: 'after' };
       const result = await this.db.findOneAndUpdate(
-        { _id: this._dbService.bsonConvert(account_id) },
+        { _id: this.dbService.bsonConvert(account_id) },
         { $set: update },
         options,
       );

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { HomePageComponent } from './pages/home-page/home-page.component';
-import { AuthGuard } from './utility/guards';
+import { AuthGuardFn } from './utility/guards';
 
 const routes: Routes = [
   {
@@ -21,13 +21,12 @@ const routes: Routes = [
   {
     path: '',
     component: HomePageComponent,
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuardFn],
   },
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule],
-  providers: [AuthGuard],
 })
 export class AppRoutingModule {}

--- a/frontend/src/app/pages/account-page/account-routing.module.ts
+++ b/frontend/src/app/pages/account-page/account-routing.module.ts
@@ -1,15 +1,14 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AccountPageComponent } from './account-page.component';
-import { AuthGuard } from '../../utility/guards';
+import { AuthGuardFn } from '../../utility/guards';
 
 const routes: Routes = [
-  { path: '', component: AccountPageComponent, canActivate: [AuthGuard] },
+  { path: '', component: AccountPageComponent, canActivate: [AuthGuardFn] },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
-  providers: [AuthGuard],
 })
 export class AccountRoutingModule {}

--- a/frontend/src/app/pages/users-page/users-page-routing.module.ts
+++ b/frontend/src/app/pages/users-page/users-page-routing.module.ts
@@ -1,20 +1,19 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { AdminGuard, AuthGuard } from '../../utility/guards';
+import { AdminGuardFn, AuthGuardFn } from '../../utility/guards';
 import { UsersPageComponent } from './users-page.component';
 
 const routes: Routes = [
   {
     path: '',
     component: UsersPageComponent,
-    canActivate: [AuthGuard, AdminGuard],
+    canActivate: [AuthGuardFn, AdminGuardFn],
   },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
-  providers: [AuthGuard, AdminGuard],
 })
 export class UsersPageRoutingModule {}

--- a/frontend/src/app/utility/guards/admin.guard.ts
+++ b/frontend/src/app/utility/guards/admin.guard.ts
@@ -1,21 +1,10 @@
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  Router,
-  RouterStateSnapshot,
-} from '@angular/router';
-import { Injectable } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
 import { UserService } from '../../services';
 
-@Injectable()
-export class AdminGuard implements CanActivate {
-  constructor(private _user: UserService, private _router: Router) {}
-
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    if (this._user.isAdmin) {
-      return true;
-    } else {
-      return this._router.navigate(['']);
-    }
+export const AdminGuardFn: CanActivateFn = () => {
+  if (inject(UserService).isAdmin) {
+    return true;
   }
-}
+  return inject(Router).navigate(['']);
+};

--- a/frontend/src/app/utility/guards/auth.guard.ts
+++ b/frontend/src/app/utility/guards/auth.guard.ts
@@ -1,21 +1,10 @@
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  Router,
-  RouterStateSnapshot,
-} from '@angular/router';
-import { Injectable } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
 import { AuthService } from '../../services';
 
-@Injectable()
-export class AuthGuard implements CanActivate {
-  constructor(private _authService: AuthService, private _router: Router) {}
-
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    if (this._authService.authenticated$.value.auth) {
-      return true;
-    } else {
-      return this._router.navigate(['/login']);
-    }
+export const AuthGuardFn: CanActivateFn = () => {
+  if (inject(AuthService).authenticated$.value.auth) {
+    return true;
   }
-}
+  return inject(Router).navigate(['/login']);
+};


### PR DESCRIPTION
This PR setups a standalone `DatabaseModule` and `DatabaseService` that based on the chosen provider will initialize the DB and extend the `DatabaseService` from the provider's subservice.

Currently the project is only setup to support MongoDB.

On the front-end it removes the deprecated `CanActivate` guards in favor of new `CanActivateFn` functions.